### PR TITLE
Fix ReadTheDocs build error: remove unsupported python.system_packages key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,7 +36,6 @@ python:
       extra_requirements:
         - docs
     - requirements: requirements.txt
-  system_packages: false
 
 # Specify which files/directories to include in the build
 # This helps reduce build time by excluding unnecessary files


### PR DESCRIPTION
## Problem
ReadTheDocs build was failing with the error:
`Invalid configuration key: python.system_packages`

## Solution
Removed the deprecated `python.system_packages: false` configuration key from `.readthedocs.yaml`. This key was deprecated and removed from ReadTheDocs configuration format v2.

## Changes
- Removed line `system_packages: false` from the python configuration section
- All other configuration options remain unchanged

## Testing
- Verified YAML syntax is still valid
- ReadTheDocs build should now pass successfully

Fixes the documentation build failure at readthedocs.org.